### PR TITLE
Persist sources and layers when switching a map's base style

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,12 @@ Here’s how to use the `StyleFlipperControl` in a simple HTML file:
 
         // Add the control to the map
         map.addControl(styleFlipperControl, "bottom-left");
+
+        // Save custom sources and layers before changing the style
+        styleFlipperControl.saveCustomSourcesAndLayers();
+
+        // Restore custom sources and layers after changing the style
+        styleFlipperControl.restoreCustomSourcesAndLayers();
     </script>
 </body>
 </html>
@@ -141,6 +147,12 @@ new StyleFlipperControl(styles, onStyleChange);
 - **`setCurrentStyleCode(code)`**:
   - Sets the current style code and highlights the corresponding button.
   - **`code`**: The code of the style to set as active.
+
+- **`saveCustomSourcesAndLayers()`**:
+  - Saves the current custom sources and layers.
+
+- **`restoreCustomSourcesAndLayers()`**:
+  - Restores the saved custom sources and layers.
 
 ---
 


### PR DESCRIPTION
Fixes #1

Add persistence for custom sources and layers when switching map styles.

* Add `saveCustomSourcesAndLayers` method to save current custom sources and layers in `index.js`.
* Add `restoreCustomSourcesAndLayers` method to restore saved custom sources and layers in `index.js`.
* Modify the click event listener to call `saveCustomSourcesAndLayers` before changing the style and `restoreCustomSourcesAndLayers` after changing the style in `index.js`.
* Update `README.md` to include the new methods `saveCustomSourcesAndLayers` and `restoreCustomSourcesAndLayers` in the usage example and API Reference section.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/geoglify/maplibre-gl-style-flipper/pull/2?shareId=8cfc0cde-10ed-4e30-9a1e-4d98993d1c64).